### PR TITLE
Don't require Github or branch to be specified

### DIFF
--- a/lib/capistrano/notifier/base.rb
+++ b/lib/capistrano/notifier/base.rb
@@ -10,7 +10,7 @@ class Capistrano::Notifier::Base
   end
 
   def branch
-    cap.branch
+    cap.respond_to?(:branch) ? cap.branch : 'master'
   end
 
   def cap

--- a/lib/capistrano/notifier/mail.rb
+++ b/lib/capistrano/notifier/mail.rb
@@ -68,11 +68,20 @@ class Capistrano::Notifier::Mail < Capistrano::Notifier::Base
   end
 
   def html
-    body.gsub(
-      /([0-9a-f]{7})\.\.([0-9a-f]{7})/, "<a href=\"#{github_compare_prefix}/\\1...\\2\">\\1..\\2</a>"
-    ).gsub(
-      /^([0-9a-f]{7})/, "<a href=\"#{github_commit_prefix}/\\0\">\\0</a>"
-    )
+    if gitub.nil?
+      body
+    else
+      body.gsub(
+        /([0-9a-f]{7})\.\.([0-9a-f]{7})/, "<a href=\"#{github_compare_prefix}/\\1...\\2\">\\1..\\2</a>"
+      ).gsub(
+        /^([0-9a-f]{7})/, "<a href=\"#{github_commit_prefix}/\\0\">\\0</a>"
+      )
+    end
+  end
+
+  def text
+    body.gsub(/([0-9a-f]{7})\.\.([0-9a-f]{7})/, "#{github_compare_prefix}/\\1...\\2") unless gitub.nil?
+    body
   end
 
   def notify_method
@@ -81,10 +90,6 @@ class Capistrano::Notifier::Mail < Capistrano::Notifier::Base
 
   def subject
     "#{application.titleize} branch #{branch} deployed to #{stage}"
-  end
-
-  def text
-    body.gsub(/([0-9a-f]{7})\.\.([0-9a-f]{7})/, "#{github_compare_prefix}/\\1...\\2")
   end
 
   def to


### PR DESCRIPTION
These commits resolve issue #9 by not hyperlinking to github if no github repo is referenced.  It also fixes another issue I came across which is that capistrano does not require branch to be set and defaults to 'master' if not specified.  Otherwise an exception is raised: "#branch is not a method"
