### PR TITLE
Attach notifiers to after deploy:restart

### DIFF
--- a/lib/capistrano/notifier/mail.rb
+++ b/lib/capistrano/notifier/mail.rb
@@ -13,7 +13,7 @@ class Capistrano::Notifier::Mail < Capistrano::Notifier::Base
         end
       end
 
-      after 'deploy', 'deploy:notify:mail'
+      after 'deploy:restart', 'deploy:notify:mail'
     end
   end
 

--- a/lib/capistrano/notifier/statsd.rb
+++ b/lib/capistrano/notifier/statsd.rb
@@ -15,7 +15,7 @@ class Capistrano::Notifier::StatsD < Capistrano::Notifier::Base
         end
       end
 
-      after 'deploy', 'deploy:notify:statsd'
+      after 'deploy:restart', 'deploy:notify:statsd'
     end
   end
 


### PR DESCRIPTION
I noticed that the notify events were only being called for cap deploy, but not for cap deploy:migrations.  This attaches the default notifier events to deploy:restart since restart is called by both the default deploy task and the migrations one.
