### PR TITLE
Added the -n flag to the echo

### DIFF
--- a/lib/capistrano/notifier/statsd.rb
+++ b/lib/capistrano/notifier/statsd.rb
@@ -20,7 +20,7 @@ class Capistrano::Notifier::StatsD < Capistrano::Notifier::Base
   end
 
   def command
-    "echo #{packet.gsub('|', '\\|')} | nc -w 1 -u #{host} #{port}"
+    "echo -n #{packet.gsub('|', '\\|')} | nc -w 1 -u #{host} #{port}"
   end
 
   private

--- a/spec/capistrano/notifier/statsd_spec.rb
+++ b/spec/capistrano/notifier/statsd_spec.rb
@@ -21,7 +21,7 @@ describe Capistrano::Notifier::StatsD do
 
   it "creates a command" do
     subject.command.should ==
-      "echo example.deploy:1\\|c | nc -w 1 -u 127.0.0.1 8125"
+      "echo -n example.deploy:1\\|c | nc -w 1 -u 127.0.0.1 8125"
   end
 
   context "with a stage" do


### PR DESCRIPTION
According with the new specification of statsd each packet could be separated by a newline. the `echo -n` just fix the problem  of `Bad line: 1 in msg ""`
