### PR TITLE
Handle case when previous revision is nil for initial deployments

### DIFF
--- a/lib/capistrano/notifier/base.rb
+++ b/lib/capistrano/notifier/base.rb
@@ -18,7 +18,7 @@ class Capistrano::Notifier::Base
   end
 
   def git_current_revision
-    cap.current_revision[0,7] if cap.respond_to? :current_revision
+    cap.current_revision.try(:[], 0,7) if cap.respond_to?(:current_revision)
   end
 
   def git_log
@@ -28,7 +28,7 @@ class Capistrano::Notifier::Base
   end
 
   def git_previous_revision
-    cap.previous_revision[0,7] if cap.respond_to? :previous_revision
+    cap.previous_revision.try(:[], 0,7) if cap.respond_to?(:previous_revision)
   end
 
   def git_range


### PR DESCRIPTION
When doing an initial deployment cap notifier will completely fail if previous revision is undefined.  I just added in a try to handle this case and return nil, since nils are handled gracefully by the git_range method already.

This should address issue: https://github.com/cramerdev/capistrano-notifier/issues/51
