### PR TITLE
Replace string parameter to split method in HTML template with a regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,16 @@ This gem comes with two different templates that are used to generate the body o
 The following are the default values for the template options:
 
  - `format`: `:text`
- - `templates_path`: `config/deploy/templates`
- - `template`: `mail.#{format}.erb`. Note the dependency of this option on `format`.
+ - `templates_path`: `"config/deploy/templates"`
+ - `template`: `"mail.#{format}.erb"`. Note the dependency of this option on `format`.
 
 The relationship between these variables might seem a bit complex but provides great flexiility. The logic used is as follows:
 
- - If the file exists in `#{templates_path}/#{template}`, then use that one.
+ - If the file exists in `"#{templates_path}/#{template}"`, then use that one.
    - With no option set, this will default to `config/deploy/templates/mail.text.erb`.
 
- - If the file doesn't exist in the previous path, load `#{template}` from one of the gem's templates, either `mail.text.erb` or `mail.html.erb`.
-   - With no options set, this will default to `mail.text.erb`.
+ - If the file doesn't exist in the previous path, load `"#{template}"` from one of the gem's templates, either `mail.text.erb` or `mail.html.erb`.
+   - With no options set, this will default to `mail.text.erb` due to how the `template` option is generated. See above.
 
 ## StatsD
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For those interested in creating customized templates, it is important to know t
 <%= cap.any_variable_defined_in_capistrano %>
 ```
 
-The following is a lis of some popular variables that don't require the use of the `cap.` prefix:
+The following is a list of some popular variables that don't require the use of the `cap.` prefix:
 
  - `application`: Name of the application.
  - `branch`: Name of the branch to be deployed.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,24 @@ set :notifier_mail_options, {
 }
 ```
 
+### Templates
+
+This gem comes with two different templates that are used to generate the body of the email. To choose from each one of them, you can set the `format` option to either `:html` - for HTML emails - or `:text` - for plain text.
+
+The following are the default values for the template options:
+
+ - `format`: `:text`
+ - `templates_path`: `config/deploy/templates`
+ - `template`: `mail.#{format}.erb`. Note the dependency of this option on `format`.
+
+The relationship between these variables might seem a bit complex but provides great flexiility. The logic used is as follows:
+
+ - If the file exists in `#{templates_path}/#{template}`, then use that one.
+   - With no option set, this will default to `config/deploy/templates/mail.text.erb`.
+
+ - If the file doesn't exist in the previous path, load `#{template}` from one of the gem's templates, either `mail.text.erb` or `mail.html.erb`.
+   - With no options set, this will default to `mail.text.erb`.
+
 ## StatsD
 
 ```rb

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ set :notifier_mail_options, {
 
 ### Templates
 
-This gem comes with two different templates that are used to generate the body of the email. To choose from each one of them, you can set the `format` option to either `:html` - for HTML emails - or `:text` - for plain text.
+This gem comes with two different ERB templates that are used to generate the body of the email. To choose from each one of them, you can set the `format` option to either `:html` - for HTML emails - or `:text` - for plain text.
 
 The following are the default values for the template options:
 
@@ -70,6 +70,29 @@ The relationship between these variables might seem a bit complex but provides g
  - If the file exists in `"#{templates_path}/#{template}"`, then use that one. With no option set, this will default to `config/deploy/templates/mail.text.erb`.
 
  - If the file doesn't exist in the previous path, load `"#{template}"` from one of the gem's templates, either `mail.text.erb` or `mail.html.erb`. With no options set, this will default to `mail.text.erb` due to how the `template` option is generated. See above.
+
+For those interested in creating customized templates, it is important to know that you can use any of the variables defined in capistrano by prefixing it with the `cap` method like below:
+
+```rb
+<%= cap.any_variable_defined_in_capistrano %>
+```
+
+The following is a lis of some popular variables that don't require the use of the `cap.` prefix:
+
+ - `application`: Name of the application.
+ - `branch`: Name of the branch to be deployed.
+ - `git_commit_prefix`: URL of the format `"#{git_prefix}/commit"`.
+ - `git_compare_prefix`: URL of the format `"#{git_prefix}/compare"`.
+ - `git_current_version`: Commit for current revision.
+ - `git_log`: Simplified log of commits in the `git_range`.
+ - `git_prefix`: URL to the github repository. Depends on `giturl` or `github` variables.
+ - `git_previous_revision`: Commit for previous revision.
+ - `git_range`: Range of commits between previous and current revision. Example: xxx..yyy
+ - `github`: URL path to the GitHub respository. Ex: 'MyCompany/project-name'.
+ - `giturl`: Base URL to the repository.
+ - `now`: Current time.
+ - `stage`: Name of the stage from the capistrano multistage extension.
+ - `user_name`: Name of the local git author.
 
 ## StatsD
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The following are the default values for the template options:
  - `templates_path`: `"config/deploy/templates"`
  - `template`: `"mail.#{format}.erb"`. Note the dependency of this option on `format`.
 
-The relationship between these variables might seem a bit complex but provides great flexiility. The logic used is as follows:
+The relationship between these variables might seem a bit complex but provides great flexibility. The logic used is as follows:
 
  - If the file exists in `"#{templates_path}/#{template}"`, then use that one. With no option set, this will default to `config/deploy/templates/mail.text.erb`.
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,9 @@ The following are the default values for the template options:
 
 The relationship between these variables might seem a bit complex but provides great flexiility. The logic used is as follows:
 
- - If the file exists in `"#{templates_path}/#{template}"`, then use that one.
-   - With no option set, this will default to `config/deploy/templates/mail.text.erb`.
+ - If the file exists in `"#{templates_path}/#{template}"`, then use that one. With no option set, this will default to `config/deploy/templates/mail.text.erb`.
 
- - If the file doesn't exist in the previous path, load `"#{template}"` from one of the gem's templates, either `mail.text.erb` or `mail.html.erb`.
-   - With no options set, this will default to `mail.text.erb` due to how the `template` option is generated. See above.
+ - If the file doesn't exist in the previous path, load `"#{template}"` from one of the gem's templates, either `mail.text.erb` or `mail.html.erb`. With no options set, this will default to `mail.text.erb` due to how the `template` option is generated. See above.
 
 ## StatsD
 

--- a/lib/capistrano/notifier/mail.rb
+++ b/lib/capistrano/notifier/mail.rb
@@ -126,7 +126,7 @@ class Capistrano::Notifier::Mail < Capistrano::Notifier::Base
       config_file = File.join(File.dirname(__FILE__), "templates/#{template_name}")
     end
 
-    ERB.new(File.read(config_file)).result(binding)
+    ERB.new(File.read(config_file), nil, '-').result(binding)
   end
 
   def templates_path

--- a/lib/capistrano/notifier/templates/mail.html.erb
+++ b/lib/capistrano/notifier/templates/mail.html.erb
@@ -34,7 +34,7 @@
     <p><%= git_compare_prefix %>/<%= git_range.gsub('..', '...') %></p>
 
     <h3>Commits:</h3>
-    <% git_log.split('\n').each do |commit| %>
+    <% git_log.split(/\n/).each do |commit| %>
       <p><%= commit %></p>
     <% end %>
 

--- a/lib/capistrano/notifier/templates/mail.html.erb
+++ b/lib/capistrano/notifier/templates/mail.html.erb
@@ -34,9 +34,9 @@
     <p><%= git_compare_prefix %>/<%= git_range.gsub('..', '...') %></p>
 
     <h3>Commits:</h3>
-    <% git_log.split(/\n/).each do |commit| %>
+    <%- git_log.split(/\n/).each do |commit| -%>
       <p><%= commit %></p>
-    <% end %>
+    <%- end -%>
 
   </body>
 </html>

--- a/spec/capistrano/notifier/mail_spec.rb
+++ b/spec/capistrano/notifier/mail_spec.rb
@@ -172,7 +172,7 @@ describe Capistrano::Notifier::Mail do
                 </tr>
                 <tr>
                   <td><strong>Time:</strong></td>
-                  <td>01/01/2012 at 12:00 AM IST</td>
+                  <td>01/01/2012 at 12:00 AM #{Time.now.zone}</td>
                 </tr>
               </tbody>
             </table>

--- a/spec/capistrano/notifier/mail_spec.rb
+++ b/spec/capistrano/notifier/mail_spec.rb
@@ -137,4 +137,56 @@ describe Capistrano::Notifier::Mail do
 
     BODY
   end
+
+  context 'given the format is set to :html' do
+    before do
+      subject.stub(:format).and_return(:html)
+    end
+
+    it 'renders an html email' do
+      subject.send(:text).should == <<-BODY.gsub(/^ {8}/, '')
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+          </head>
+          <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
+            <h3>Details:</h3>
+            <table>
+              <tbody>
+                <tr>
+                  <td><strong>Deployer:</strong></td>
+                  <td>John Doe</td>
+                </tr>
+                <tr>
+                  <td><strong>Application:</strong></td>
+                  <td>Example</td>
+                </tr>
+                <tr>
+                  <td><strong>Branch:</strong></td>
+                  <td>master</td>
+                </tr>
+                <tr>
+                  <td><strong>Environment:</strong></td>
+                  <td>test</td>
+                </tr>
+                <tr>
+                  <td><strong>Time:</strong></td>
+                  <td>01/01/2012 at 12:00 AM IST</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3>Compare:</h3>
+            <p>https://github.com/example/example/compare/890abcd...1234567</p>
+
+            <h3>Commits:</h3>
+              <p>1234567 This is the current commit (John Doe)</p>
+              <p>890abcd This is the previous commit (John Doe)</p>
+
+          </body>
+        </html>
+      BODY
+    end
+  end
 end


### PR DESCRIPTION
This should now properly split the commits in new lines.
