### PR TITLE
Align summary values in text email template

### DIFF
--- a/lib/capistrano/notifier/templates/mail.text.erb
+++ b/lib/capistrano/notifier/templates/mail.text.erb
@@ -1,8 +1,8 @@
-Deployer: <%= user_name %>
-Application: <%= application.titleize %>
-Branch: <%= branch %>
-Environment: <%= stage %>
-Time: <%= now.strftime("%m/%d/%Y") %> at <%= now.strftime("%I:%M %p %Z") %>
+Deployer:     <%= user_name %>
+Application:  <%= application.titleize %>
+Branch:       <%= branch %>
+Environment:  <%= stage %>
+Time:         <%= now.strftime("%m/%d/%Y") %> at <%= now.strftime("%I:%M %p %Z") %>
 
 Compare:
 <%= git_compare_prefix %>/<%= git_range.gsub('..', '...') %>

--- a/spec/capistrano/notifier/mail_spec.rb
+++ b/spec/capistrano/notifier/mail_spec.rb
@@ -132,11 +132,11 @@ describe Capistrano::Notifier::Mail do
 
   it 'renders a plaintext email' do
     subject.send(:text).should == <<-BODY.gsub(/^ {6}/, '')
-      Deployer: John Doe
-      Application: Example
-      Branch: master
-      Environment: test
-      Time: 01/01/2012 at 12:00 AM #{Time.now.zone}
+      Deployer:     John Doe
+      Application:  Example
+      Branch:       master
+      Environment:  test
+      Time:         01/01/2012 at 12:00 AM #{Time.now.zone}
 
       Compare:
       https://github.com/example/example/compare/890abcd...1234567


### PR DESCRIPTION
Aligning these values in the text email template will make it a little
easier to scan and a little more aesthetically pleasing.

Before example:

```
Deployer: John Doe
Application: Application
Branch: master
Environment: test
Time: 01/09/2014 at 03:44 PM PDT
```

After example:

```
Deployer:     John Doe
Application:  Application
Branch:       master
Environment:  test
Time:         01/09/2014 at 03:44 PM PDT
```
