### PR TITLE
Fix for escape character being included in current_revision and previous_revision methods 

### DIFF
--- a/lib/capistrano/notifier/base.rb
+++ b/lib/capistrano/notifier/base.rb
@@ -34,7 +34,7 @@ class Capistrano::Notifier::Base
   def git_range
     return unless git_previous_revision && git_current_revision
 
-    "#{git_previous_revision[2..8]}...#{git_current_revision[2..8]}"
+    "#{git_previous_revision.gsub("\r\n","")}...#{git_current_revision.gsub("\r\n","")}"
   end
 
   def now

--- a/lib/capistrano/notifier/base.rb
+++ b/lib/capistrano/notifier/base.rb
@@ -34,7 +34,7 @@ class Capistrano::Notifier::Base
   def git_range
     return unless git_previous_revision && git_current_revision
 
-    "#{git_previous_revision}..#{git_current_revision}"
+    "#{git_previous_revision[2..8]}...#{git_current_revision[2..8]}"
   end
 
   def now

--- a/lib/capistrano/notifier/templates/mail.html.erb
+++ b/lib/capistrano/notifier/templates/mail.html.erb
@@ -31,7 +31,7 @@
     </table>
 
     <h3>Compare:</h3>
-    <p><%= git_compare_prefix %>/<%= git_range.gsub('..', '...') %></p>
+    <p><%= git_compare_prefix %>/<%= git_range %></p>
 
     <h3>Commits:</h3>
     <%- git_log.split(/\n/).each do |commit| -%>

--- a/lib/capistrano/notifier/templates/mail.text.erb
+++ b/lib/capistrano/notifier/templates/mail.text.erb
@@ -5,7 +5,7 @@ Environment:  <%= stage %>
 Time:         <%= now.strftime("%m/%d/%Y") %> at <%= now.strftime("%I:%M %p %Z") %>
 
 Compare:
-<%= git_compare_prefix %>/<%= git_range.gsub('..', '...') %>
+<%= git_compare_prefix %>/<%=git_range %>
 
 Commits:
 <%= git_log %>


### PR DESCRIPTION
Removed the escape characters in current_revision and previous_revision from the string returned from capistrano. I also removed the gsub("...", "..") as the github api now uses "..." the log and compare
#58
